### PR TITLE
Auto-generate component index from frontmatter; bump CI to Node 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'npm'
 
       - run: npm ci

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,7 +19,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'npm'
 
       - run: npm ci

--- a/docs/components/ComponentDescription.astro
+++ b/docs/components/ComponentDescription.astro
@@ -1,0 +1,4 @@
+---
+const { description } = Astro.locals.starlightRoute.entry.data
+---
+{description && <p>{description}</p>}

--- a/docs/components/ComponentList.astro
+++ b/docs/components/ComponentList.astro
@@ -1,0 +1,15 @@
+---
+import { base } from 'astro:config/client'
+import { getCollection } from 'astro:content'
+
+const entries = (await getCollection('docs'))
+  .filter(entry => entry.id !== 'index')
+  .sort((a, b) => a.data.title.localeCompare(b.data.title))
+---
+
+{entries.map(entry => (
+  <section>
+    <h2><a href={`${base}/${entry.id}/`}>{entry.data.title}</a></h2>
+    {entry.data.description && <p>{entry.data.description}</p>}
+  </section>
+))}

--- a/docs/content/climb-performance.mdx
+++ b/docs/content/climb-performance.mdx
@@ -4,8 +4,11 @@ description: Side-by-side interactive charts showing Thrust vs Airspeed and Powe
 ---
 
 import ClimbPerformance from '../components/ClimbPerformance.astro'
+import ComponentDescription from '../components/ComponentDescription.astro'
 
-Side-by-side interactive charts showing **Thrust vs Airspeed** and **Power vs Airspeed** for a propeller aircraft. The green-shaded region in each chart is the excess available over required — this excess is what enables climbing. Drag the cursor across both charts to explore how excess thrust (which drives climb *angle*, Vx) and excess power (which drives climb *rate*, Vy) vary with airspeed.
+<ComponentDescription />
+
+The green-shaded region in each chart is the excess available over required — this excess is what enables climbing. Drag the cursor across both charts to explore how excess thrust (which drives climb *angle*, Vx) and excess power (which drives climb *rate*, Vy) vary with airspeed.
 
 <ClimbPerformance />
 

--- a/docs/content/climb-performance.mdx
+++ b/docs/content/climb-performance.mdx
@@ -1,5 +1,5 @@
 ---
-title: ClimbPerformance
+title: Climb Performance
 description: Side-by-side interactive charts showing Thrust vs Airspeed and Power vs Airspeed for a propeller aircraft.
 ---
 

--- a/docs/content/flight-path-overview.mdx
+++ b/docs/content/flight-path-overview.mdx
@@ -1,11 +1,14 @@
 ---
 title: Flight Path Overview
-description: A pure-SVG visualization of a flight plan as a sequence of lesson topics, with animated waypoint progression and variance tracking.
+description: A pure-SVG visualisation of a flight plan as a sequence of lesson topics — departure runway on the left, arrival runway on the right, and a dashed flight path with numbered waypoints between them.
 ---
 
 import FlightPathOverview from '../components/FlightPathOverview.astro'
+import ComponentDescription from '../components/ComponentDescription.astro'
 
-A pure-SVG visualisation of a flight plan as a sequence of *lesson topics* — departure runway on the left, arrival runway on the right, and a dashed flight path with numbered waypoints between them. As the plane advances through the topics, the actual elapsed time is recorded against the planned time and a variance indicator shows whether the lesson is on track.
+<ComponentDescription />
+
+The departure runway sits on the left, arrival on the right, with a dashed flight path and numbered *lesson topic* waypoints between them. As the plane advances through the topics, the actual elapsed time is recorded against the planned time and a variance indicator shows whether the lesson is on track.
 
 <FlightPathOverview />
 

--- a/docs/content/flight-path-overview.mdx
+++ b/docs/content/flight-path-overview.mdx
@@ -1,5 +1,5 @@
 ---
-title: FlightPathOverview
+title: Flight Path Overview
 description: A pure-SVG visualization of a flight plan as a sequence of lesson topics, with animated waypoint progression and variance tracking.
 ---
 

--- a/docs/content/four-forces.mdx
+++ b/docs/content/four-forces.mdx
@@ -4,8 +4,11 @@ description: An interactive 3D visualization of the four aerodynamic forces — 
 ---
 
 import FourForces from '../components/FourForces.astro'
+import ComponentDescription from '../components/ComponentDescription.astro'
 
-An interactive 3D visualization of the four aerodynamic forces — Lift, Weight, Thrust, and Drag — shown as arrows on an aircraft model. Power and Attitude sliders drive a physics model; the arrows scale dynamically to reflect the force balance. Includes ASI and VSI instrument gauges, airflow particle stream, and weight-component decomposition during climbs. Supports cross-tab synchronization via BroadcastChannel for presenter/slide pairing.
+<ComponentDescription />
+
+Power and Attitude sliders drive a physics model; the arrows scale dynamically to reflect the force balance. Includes ASI and VSI instrument gauges, airflow particle stream, and weight-component decomposition during climbs. Supports cross-tab synchronization via BroadcastChannel for presenter/slide pairing.
 
 <FourForces />
 

--- a/docs/content/four-forces.mdx
+++ b/docs/content/four-forces.mdx
@@ -1,5 +1,5 @@
 ---
-title: FourForces
+title: Four Forces
 description: An interactive 3D visualization of the four aerodynamic forces — Lift, Weight, Thrust, and Drag — shown as arrows on an aircraft model.
 ---
 

--- a/docs/content/index.mdx
+++ b/docs/content/index.mdx
@@ -3,19 +3,11 @@ title: Open Aviation Components
 description: Interactive web components for aviation training. Framework-agnostic custom elements — use them anywhere.
 ---
 
+import ComponentList from '../components/ComponentList.astro'
+
 Interactive aviation training web components. Framework-agnostic custom elements — embed them in any HTML page, framework, or presentation tool.
 
-## [Four Forces](/open-aviation-components/four-forces/)
-
-3D visualization of lift, weight, thrust, and drag with a live physics model, ASI and VSI instruments, and airflow particles.
-
-## [Climb Performance](/open-aviation-components/climb-performance/)
-
-Interactive thrust and power vs airspeed charts showing Vx (best angle of climb) and Vy (best rate of climb).
-
-## [Flight Path Overview](/open-aviation-components/flight-path-overview/)
-
-SVG flight plan with waypoints, segment times, and live variance tracking.
+<ComponentList />
 
 ## Installation
 


### PR DESCRIPTION
## Summary

- Replaces hand-written component summaries in `index.mdx` with `ComponentList.astro`, which reads titles and descriptions directly from content collection frontmatter — new components appear automatically without editing the index page
- Corrects component page titles to use proper spacing (`Four Forces`, `Climb Performance`, `Flight Path Overview`)
- Updates CI and deploy workflows from Node 20 to Node 24 (Astro requires `>=22.12.0`)

## Test plan

- [ ] Index page lists all three components with correct titles and descriptions
- [ ] Clicking each component link navigates correctly (no 404)
- [ ] CI passes with Node 24