### PR TITLE
Fix aerofoil rasteriser scanline bug and cap AoA at stall angle

### DIFF
--- a/docs/content/aerofoil-dynamics.mdx
+++ b/docs/content/aerofoil-dynamics.mdx
@@ -32,11 +32,13 @@ At the default speed (0.4) the LBM runs at **Re ≈ 150**, because the lattice M
 | Bumblebee | 3 mm | 1 m/s | ~200 |
 | **This simulation (speed=0.4)** | — | — | **~150** |
 
-At Re ≈ 150, viscous skin friction is roughly 50× larger than at Cessna Re, so C_D is greatly inflated and the lift-to-drag ratio (≈ 0.9 here vs ≈ 50–80 for a real wing) is not representative of aircraft performance. C_L is qualitatively correct — the right sign, and it rises with AoA and drops at stall — but its magnitude is somewhat depressed by the thick laminar boundary layer.
+At Re ≈ 150, viscous skin friction is roughly 50× larger than at Cessna Re, so C_D is greatly inflated and the lift-to-drag ratio (≈ 0.9 here vs ≈ 50–80 for a real wing) is not representative of aircraft performance. C_L rises with AoA, has the right sign, and shows visible flow separation and wake growth as α approaches the real stall angle.
+
+**Note on post-stall behaviour.** A real wing's lift drops sharply at the stall angle because the upper-surface boundary layer detaches close to the leading edge and the suction peak collapses. Resolving that requires a boundary layer many cells thick across the chord — at the simulated Re and grid resolution there is essentially no resolved boundary layer (δ/chord ≈ 1/√Re ≈ 1 grid cell), so the suction-peak-collapse mechanism cannot be reproduced. Past the real stall angle C_L would therefore plateau rather than drop, which is misleading; for this reason the AoA slider is capped at ±16°, around the real-world stall angle of NACA 2412.
 
 The simulation cannot be simply rescaled to Cessna Re: the flow topology is different (thick separated boundary layer vs thin attached one), so the coefficients reflect different physics, not the same physics at a different magnitude. Achieving Re > 1 000 in a real-time 200 × 80 browser simulation would require turbulence modelling and a larger grid.
 
-**The component is therefore best used as a qualitative flow visualiser** — it correctly shows flow acceleration over the upper surface, pressure-driven lift, wake formation, and stall onset. The displayed C_L and C_D values are physically correct for the simulated Re but should not be compared directly to published aerofoil data.
+**The component is therefore best used as a qualitative flow visualiser** — it correctly shows flow acceleration over the upper surface, pressure-driven lift, wake formation, and the onset of stall up to α_stall. The displayed C_L and C_D values are physically correct for the simulated Re but should not be compared directly to published aerofoil data.
 
 ### Incompressible assumption
 
@@ -75,9 +77,10 @@ The aerofoil silhouette is drawn as a smooth path on top of the upscaled vortici
 
 | Attribute | Default | Description |
 |-----------|---------|-------------|
+| `height` | `420px` | CSS height of the component |
 | `naca` | `2412` | [National Advisory Committee for Aeronautics (NACA)](https://en.wikipedia.org/wiki/NACA_airfoil) 4-digit profile code |
 | `speed` | `0.4` | Normalised inflow speed (0–1) |
-| `aoa` | `5` | Angle of attack in degrees (−20 to +20) |
+| `aoa` | `5` | Angle of attack in degrees (−16 to +16) |
 | `show-controls` | _(absent)_ | Renders speed and AoA sliders inside the component |
 
 ## Events

--- a/src/components/AerofoilDynamics/index.css
+++ b/src/components/AerofoilDynamics/index.css
@@ -6,7 +6,7 @@
 
 :host {
   display: block;
-  min-height: 360px;
+  height: 420px;
 }
 
 .ad-root {

--- a/src/components/AerofoilDynamics/index.ts
+++ b/src/components/AerofoilDynamics/index.ts
@@ -137,28 +137,29 @@ function rasteriseAerofoil(
   for (let col = xMin; col <= xMax; col++) {
     let yTopMin = Infinity, yBotMax = -Infinity
 
-    // Scan upper surface — find the highest (smallest y in canvas coords, most negative local y)
+    // Scan upper surface — find the highest (smallest y in canvas coords, most negative local y).
+    // Only segments that actually straddle integer `col` contribute; interpolate in the segment's
+    // own direction (t=0 at point i, t=1 at point i+1) so that backward-going segments still
+    // resolve to the correct y at the crossing.
     for (let i = 0; i < upper.length - 1; i++) {
       const [x0, y0] = toGrid(upper[i].x, upper[i].y)
       const [x1, y1] = toGrid(upper[i+1].x, upper[i+1].y)
-      const xLo = Math.min(x0, x1), xHi = Math.max(x0, x1)
-      if (xLo <= col + 0.5 && xHi >= col - 0.5) {
-        const t = xHi === xLo ? 0.5 : (col - xLo) / (xHi - xLo)
-        const y = y0 + t * (y1 - y0)
-        if (y < yTopMin) yTopMin = y
-      }
+      const xMinS = Math.min(x0, x1), xMaxS = Math.max(x0, x1)
+      if (col < xMinS || col > xMaxS) continue
+      const t = xMaxS === xMinS ? 0.5 : (col - x0) / (x1 - x0)
+      const y = y0 + t * (y1 - y0)
+      if (y < yTopMin) yTopMin = y
     }
 
     // Scan lower surface — find the lowest (largest y in canvas coords)
     for (let i = 0; i < lower.length - 1; i++) {
       const [x0, y0] = toGrid(lower[i].x, lower[i].y)
       const [x1, y1] = toGrid(lower[i+1].x, lower[i+1].y)
-      const xLo = Math.min(x0, x1), xHi = Math.max(x0, x1)
-      if (xLo <= col + 0.5 && xHi >= col - 0.5) {
-        const t = xHi === xLo ? 0.5 : (col - xLo) / (xHi - xLo)
-        const y = y0 + t * (y1 - y0)
-        if (y > yBotMax) yBotMax = y
-      }
+      const xMinS = Math.min(x0, x1), xMaxS = Math.max(x0, x1)
+      if (col < xMinS || col > xMaxS) continue
+      const t = xMaxS === xMinS ? 0.5 : (col - x0) / (x1 - x0)
+      const y = y0 + t * (y1 - y0)
+      if (y > yBotMax) yBotMax = y
     }
 
     if (yTopMin > yBotMax) continue
@@ -203,7 +204,7 @@ function vorticityToRgb(vort: number): [number, number, number] {
 
 // ── Component ─────────────────────────────────────────────────────────────────
 class AerofoilDynamicsElement extends HTMLElement {
-  static observedAttributes = ['naca', 'speed', 'aoa', 'hide-controls', 'show-help']
+  static observedAttributes = ['height', 'naca', 'speed', 'aoa', 'hide-controls', 'show-help']
 
   // DOM
   private _root!: HTMLDivElement
@@ -304,8 +305,8 @@ class AerofoilDynamicsElement extends HTMLElement {
     this._aoaSlider = document.createElement('input')
     this._aoaSlider.type = 'range'
     this._aoaSlider.className = 'ad-slider'
-    this._aoaSlider.min = '-20'
-    this._aoaSlider.max = '20'
+    this._aoaSlider.min = '-16'
+    this._aoaSlider.max = '16'
     this._aoaSlider.step = '0.5'
     this._aoaSlider.value = String(this._aoa)
     this._aoaDisplay = document.createElement('span')
@@ -411,7 +412,9 @@ class AerofoilDynamicsElement extends HTMLElement {
   }
 
   attributeChangedCallback(name: string, _old: string | null, value: string | null) {
-    if (name === 'naca') {
+    if (name === 'height') {
+      this.style.height = value ?? ''
+    } else if (name === 'naca') {
       this._naca = value ?? '2412'
       this._nacaSelect.value = this._naca
       if (this._sceneReady) this._rasteriseAndReset()
@@ -421,7 +424,7 @@ class AerofoilDynamicsElement extends HTMLElement {
       this._speedDisplay.textContent = this._speed.toFixed(2)
       if (this._sceneReady) this._setInflow()
     } else if (name === 'aoa') {
-      this._aoa = Math.max(-20, Math.min(20, parseFloat(value ?? '5') || 5))
+      this._aoa = Math.max(-16, Math.min(16, parseFloat(value ?? '5') || 5))
       this._aoaSlider.value = String(this._aoa)
       this._aoaDisplay.textContent = `${this._aoa.toFixed(1)}°`
       if (this._sceneReady) this._rasteriseAndReset()


### PR DESCRIPTION
## Summary

- The aerofoil rasteriser admitted near-vertical segments that didn't actually straddle the integer column being scanned, then extrapolated wildly when computing `y`. At AoA ≥ 15° this clamped a single column's solid mask all the way down to the grid boundary, producing a one-column "wall" descending from the leading edge to the bottom of the canvas — particles slid down it instead of around it. Fix by requiring `col` to lie strictly inside the segment's x-range and interpolating in the segment's own (signed) direction so backward-going segments resolve to the correct `y`.
- The simulation runs at Re ≈ 150 with a 60-cell chord, so the upper-surface boundary layer is essentially unresolved and the suction-peak collapse that drives real stall cannot be reproduced. Past the real stall angle C_L plateaus rather than drops, which would mislead users. Cap the AoA slider at ±16° (NACA 2412's real stall angle) and add a "Note on post-stall behaviour" paragraph to the docs explaining why.
- Add a `height` attribute so embeds can size the component without CSS overrides.

## Test plan

- [ ] Sweep AoA slider from −16° to +16° at default speed — flow visualises smoothly, no vertical wall artefact at any angle, no shudders or crashes.
- [ ] Sweep AoA at speed = 1.0 — same as above.
- [ ] Set `aoa="20"` programmatically — clamps to 16°.
- [ ] Set `height="500px"` on the element — component resizes accordingly.
- [ ] Read the new post-stall note in the docs — explains the simulation limitation clearly.