### PR TITLE
Add Cloudflare Web Analytics

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -13,6 +13,16 @@ export default defineConfig({
       title: 'Open Aviation Components',
       description: 'Interactive aviation training web components.',
       customCss: ['./docs/styles/custom.css'],
+      head: [
+        {
+          tag: 'script',
+          attrs: {
+            defer: true,
+            src: 'https://static.cloudflareinsights.com/beacon.min.js',
+            'data-cf-beacon': '{"token": "c996028d44e34f17a30b5bc693372d9e"}',
+          },
+        },
+      ],
       social: [
         {
           icon: 'github',


### PR DESCRIPTION
## Summary

- Adds Cloudflare Web Analytics beacon script to all docs pages via Starlight's `head` config
- Uses the shared `open-aviation-solutions.github.io` token — traffic from this site is distinguishable by path (`/open-aviation-components/…`) in the Cloudflare dashboard
- No cookies; no consent banner required