### PR TITLE
Tweak circuit-diagram example: crosswind join + exaggeration 2

### DIFF
--- a/docs/components/CircuitDiagram.astro
+++ b/docs/components/CircuitDiagram.astro
@@ -3,7 +3,7 @@
 <circuit-diagram
   height="520px"
   runway="27"
-  vertical-exaggeration="3"
+  vertical-exaggeration="2"
   show-help="false"
   wind-from="250"
   wind-speed="15"
@@ -16,10 +16,10 @@
   ></circuit-path>
 
   <circuit-path
-    label="Glide approach"
-    color="#ef444499"
-    points="0,-1000,305; -500,-950,240; -850,-650,175; -900,-250,110; -550,-50,50; 0,0,5"
-    segment-labels="0:Engine failure abeam · best glide; 2:Constant aspect turn; 4:Aim for the threshold"
+    label="Mid-field crosswind join"
+    color="#eab30899"
+    points="1550,1500,457; 1496,1700,432; 1350,1846,406; 1150,1900,381; 950,1846,356; 804,1700,330; 750,1500,305; 750,0,305; 750,-1000,305; -1500,-1000,305; -1500,0,180; 0,0,1"
+    segment-labels="0:Circling descent · 1500 ft; 6:Crosswind join · 1000 ft; 7:Cross midfield; 8:Downwind · 1000 ft; 9:Base; 10:Final"
   ></circuit-path>
 </circuit-diagram>
 

--- a/docs/content/circuit-diagram.mdx
+++ b/docs/content/circuit-diagram.mdx
@@ -14,13 +14,13 @@ Drag to orbit, scroll to zoom. Use the legend (top-left) to show or hide individ
 
 <CircuitDiagram />
 
-The example shows a standard left-hand circuit (blue) and an engine-failure **glide approach** (red) flown from the downwind leg. Toggle them in the legend to see how the glide approach trades the powered circuit's square pattern for a continuous descending turn aimed at the threshold.
+The example shows a standard left-hand circuit (blue) and a **mid-field crosswind join** (yellow). The join starts with a circling descent on the dead side from 1500 ft down to circuit height, crosses the field at mid-field, then rolls onto the downwind leg and continues around base and final to land. Toggle them in the legend, or fly the join with its play button, to see how it blends into the pattern.
 
 ## Description
 
 The viewer renders a generic flat airfield with a single labelled runway, then overlays one or more **flight paths**. Each path is a list of waypoints in metres relative to the runway, drawn as a flat, semi-transparent ribbon that climbs and descends with the waypoint altitudes. Turns are smoothed into arcs.
 
-Because a real circuit is kilometres wide but only a few hundred metres high, it would look almost flat at true scale. The `vertical-exaggeration` factor (default `3`) stretches the vertical axis so the climb gradients and pattern altitude read clearly — keep this in mind when judging heights by eye.
+Because a real circuit is kilometres wide but only a few hundred metres high, it would look almost flat at true scale. The `vertical-exaggeration` factor (default `2`) stretches the vertical axis so the climb gradients and pattern altitude read clearly — keep this in mind when judging heights by eye.
 
 ### Coordinate system
 
@@ -48,7 +48,7 @@ Altitudes are in metres for consistency, but instructors think in feet. Rather t
 Paths are declared as `<circuit-path>` child elements. Each takes a `label` (shown in the legend), a `color` (with transparency carried in the colour itself), a `points` list, and optional `segment-labels`:
 
 ```html
-<circuit-diagram runway="27" vertical-exaggeration="3">
+<circuit-diagram runway="27" vertical-exaggeration="2">
   <circuit-path
     label="Standard circuit"
     color="#3b82f6cc"
@@ -72,7 +72,7 @@ The same data can be supplied programmatically via the element's `.paths` proper
   import 'https://unpkg.com/@open-aviation-solutions/components/dist/lib/define.es.js';
 </script>
 
-<circuit-diagram runway="27" vertical-exaggeration="3">
+<circuit-diagram runway="27" vertical-exaggeration="2">
   <circuit-path label="Standard circuit" color="#3b82f6cc"
     points="0,0,0; 700,0,0; 2000,0,175; 2000,-1000,305; -1500,-1000,305; -1500,0,180; 0,0,0">
   </circuit-path>
@@ -87,7 +87,7 @@ The same data can be supplied programmatically via the element's `.paths` proper
 | `runway` | `27` | Runway designator (drives the painted number and the runway heading) |
 | `runway-length` | `1500` | Runway length in metres |
 | `runway-width` | `30` | Runway width in metres |
-| `vertical-exaggeration` | `3` | Multiplier applied to altitude for display |
+| `vertical-exaggeration` | `2` | Multiplier applied to altitude for display |
 | `path-width` | `20` | Ribbon width in metres |
 | `corner-radius` | `100` | Corner fillet radius in metres (`0` for sharp corners) |
 | `wind-from` | runway heading | Direction in degrees the wind blows *from*; orients the windsock |

--- a/src/components/CircuitDiagram/INSTRUCTIONS.md
+++ b/src/components/CircuitDiagram/INSTRUCTIONS.md
@@ -22,7 +22,7 @@ Runway-centric, metres:
 Looking down `+x` (the landing direction), Three.js puts `+z` on the viewer's
 right, so `worldZ = +y` makes `+y` read as "right" (and a left-hand circuit,
 which uses negative `y`, correctly appears on the left). Altitude is multiplied
-by `vertical-exaggeration` (default 3) because a real circuit is kilometres wide
+by `vertical-exaggeration` (default 2) because a real circuit is kilometres wide
 but only ~300 m high and would otherwise look flat.
 
 ## Key internals
@@ -141,7 +141,7 @@ optional `segment-labels`.
 | `runway` | `27` | Runway designator (drives the painted number and the runway heading) |
 | `runway-length` | `1500` | Runway length in metres |
 | `runway-width` | `90` | Runway width in metres (kept wider than `path-width` so the runway reads as the landing surface; not to scale) |
-| `vertical-exaggeration` | `3` | Multiplier applied to altitude for display |
+| `vertical-exaggeration` | `2` | Multiplier applied to altitude for display |
 | `path-width` | `60` | Ribbon width in metres (tweak via the attribute, or the `DEFAULT_PATH_WIDTH` constant for a new baseline) |
 | `corner-radius` | `100` | Corner fillet radius in metres (`0` = sharp corners) |
 | `wind-from` | runway heading | Direction in degrees the wind blows *from*; orients the windsock and the flythrough crab |

--- a/src/components/CircuitDiagram/index.ts
+++ b/src/components/CircuitDiagram/index.ts
@@ -17,7 +17,7 @@ const BROADCAST_CHANNEL = 'circuit-diagram-sync'
 const DEFAULT_RUNWAY = '27'
 const DEFAULT_RUNWAY_LENGTH = 1500
 const DEFAULT_RUNWAY_WIDTH = 90
-const DEFAULT_VERTICAL_EXAGGERATION = 3
+const DEFAULT_VERTICAL_EXAGGERATION = 2
 const DEFAULT_PATH_WIDTH = 60
 const DEFAULT_CORNER_RADIUS = 100
 /** Opacity of a path's ground curtain relative to the ribbon's own opacity. */


### PR DESCRIPTION
## Changes

Two tweaks to the `circuit-diagram` docs example, plus a default change.

### Docs example (`docs/components/CircuitDiagram.astro`)
- **Replaced the engine-failure glide approach (red) with a mid-field crosswind join (yellow).**
- The join now **starts with a circling descent** on the dead side from 1500 ft down to circuit height (a smoothed 180° half-circle), crosses the field at mid-field, then **rolls onto downwind and continues around base and final to land** — so the legend flythrough runs all the way to touchdown instead of stopping at the downwind roll-on.
- Segment labels: *Circling descent · 1500 ft → Crosswind join · 1000 ft → Cross midfield → Downwind · 1000 ft → Base → Final.*

### Default `vertical-exaggeration` 3 → 2
- `DEFAULT_VERTICAL_EXAGGERATION` in `src/components/CircuitDiagram/index.ts`.
- Docs updated to match: component `INSTRUCTIONS.md` (prose + attributes table) and `circuit-diagram.mdx` (prose, attributes table, embedding snippets, and the live example).

## Verification
- `npm run typecheck` — passes
- `npm run build` — passes